### PR TITLE
New resolution strategy syntax

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -2,15 +2,17 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/bitrise-io/bitrise/v2/bitrise"
 	"github.com/bitrise-io/bitrise/v2/models"
-
 	"github.com/bitrise-io/toolprovider/provider"
 )
 
 const keyExperimental = "experimental"
 const keyToolDeclarations = "tools"
+const latestSyntaxPattern = `(.+):latest$`
+const installedSyntaxPattern = `(.+):installed$`
 
 func ParseBitriseYml(path string) (models.BitriseDataModel, error) {
 	model, _, err := bitrise.ReadBitriseConfig(path, bitrise.ValidationTypeMinimal)
@@ -36,44 +38,52 @@ func ParseToolDeclarations(bitriseYml models.BitriseDataModel) (map[string]provi
 		return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s block is not defined", keyExperimental, keyToolDeclarations)
 	}
 
-	toolDeclarations := make(map[string]provider.ToolRequest)
-	for toolName, toolData := range toolBlock {
-		toolDataMap, ok := toolData.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s.%s block is not a map", keyExperimental, keyToolDeclarations, toolName)
-		}
+	latestSyntaxPattern, err := regexp.Compile(latestSyntaxPattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex pattern: %v", err)
+	}
+	preinstalledSyntaxPattern, err := regexp.Compile(installedSyntaxPattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regex pattern: %v", err)
+	}
 
+	toolDeclarations := make(map[string]provider.ToolRequest)
+	for toolName, toolVersion := range toolBlock {
 		// TODO: string or int
-		version, ok := toolDataMap["version"].(string)
+		versionString, ok := toolVersion.(string)
 		if !ok {
 			return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s.%s.version is not a string", keyExperimental, keyToolDeclarations, toolName)
 		}
 
 		var resolutionStrategy provider.ResolutionStrategy
-		if toolDataMap["resolution_strategy"] != nil {
-			resolutionStrategyString, ok := toolDataMap["resolution_strategy"].(string)
-			if !ok {
-				return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s.%s.resolution_strategy is not a string", keyExperimental, keyToolDeclarations, toolName)
+		var plainVersion string
+		if latestSyntaxPattern.MatchString(versionString) {
+			resolutionStrategy = provider.ResolutionStrategyLatestReleased
+			matches := latestSyntaxPattern.FindStringSubmatch(versionString)
+			if len(matches) > 1 {
+				plainVersion = matches[1]
+			} else {
+				return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s.%s.version does not match latest syntax: %s", keyExperimental, keyToolDeclarations, toolName, versionString)
 			}
-			switch resolutionStrategyString {
-			case "":
-				resolutionStrategy = provider.ResolutionStrategyStrict
-			case "strict":
-				resolutionStrategy = provider.ResolutionStrategyStrict
-			case "closest_installed":
-				resolutionStrategy = provider.ResolutionStrategyLatestInstalled
-			case "closest_released":
-				resolutionStrategy = provider.ResolutionStrategyLatestReleased
+		} else if preinstalledSyntaxPattern.MatchString(versionString) {
+			resolutionStrategy = provider.ResolutionStrategyLatestInstalled
+			matches := preinstalledSyntaxPattern.FindStringSubmatch(versionString)
+			if len(matches) > 1 {
+				plainVersion = matches[1]
+			} else {
+				return nil, fmt.Errorf("parse bitrise.yml: meta.%s.%s.%s.version does not match preinstalled syntax: %s", keyExperimental, keyToolDeclarations, toolName, versionString)
 			}
+		} else {
+			resolutionStrategy = provider.ResolutionStrategyStrict
+			plainVersion = versionString
 		}
 
 		toolDeclarations[toolName] = provider.ToolRequest{
 			ToolName:           toolName,
-			UnparsedVersion:    version,
+			UnparsedVersion:    plainVersion,
 			ResolutionStrategy: resolutionStrategy,
 		}
 	}
 
 	return toolDeclarations, nil
-
 }

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -21,11 +21,17 @@ func TestParseBitriseYml(t *testing.T) {
 				"golang": {
 					ToolName:        "golang",
 					UnparsedVersion: "1.16.3",
+					ResolutionStrategy: provider.ResolutionStrategyStrict,
 				},
 				"nodejs": {
 					ToolName:           "nodejs",
 					UnparsedVersion:    "20",
 					ResolutionStrategy: provider.ResolutionStrategyLatestInstalled,
+				},
+				"ruby": {
+					ToolName:        "ruby",
+					UnparsedVersion: "3.2",
+					ResolutionStrategy: provider.ResolutionStrategyLatestReleased,
 				},
 			},
 		},

--- a/config/testdata/valid.bitrise.yml
+++ b/config/testdata/valid.bitrise.yml
@@ -5,11 +5,9 @@ workflows: {}
 
 meta:
   bitrise.io:
-    stack: "osx-xcode-15.0.x"
+    stack: osx-xcode-15.0.x
   experimental:
     tools:
-      golang:
-        version: "1.16.3"
-      nodejs:
-        version: "20"
-        resolution_strategy: closest_installed
+      golang: 1.16.3
+      nodejs: 20:installed
+      ruby: 3.2:latest

--- a/provider/asdf/asdf.go
+++ b/provider/asdf/asdf.go
@@ -64,6 +64,7 @@ func (a *AsdfToolProvider) InstallTool(tool provider.ToolRequest) (provider.Tool
 			}
 			resolution, err = ResolveVersion(tool, releasedVersions, installedVersions)
 			if err != nil {
+				// TODO: better error here
 				return provider.ToolInstallResult{}, fmt.Errorf("resolve version: %w", err)
 			}
 		}


### PR DESCRIPTION
Essentially:

```yml
meta:
  bitrise.io:
    stack: osx-xcode-15.0.x
  experimental:
    tools:
      golang: 1.16.3
      nodejs: 20:installed
      ruby: 3.2:latest
```

A single version string is parsed and the resolution strategy is decided the following way:

- Version string ends in `:latest` -> "Latest released" strategy
- Version string ends in `:installed` -> "Latest installed" strategy
- None of the above -> "Strict" resolution strategy

This means that version strings like `nodejs: 20` or `python: 3.13` will be parsed as strict versions and will fail in practice, but we can make the error message informative. Users can decide whether they want `3.13:latest` or `3.13:installed`. Or we can change our mind and make `3.13` default to something else than "strict" strategy.