### PR TITLE
Add custom provider selection

### DIFF
--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -10,7 +10,7 @@ import (
 
 var flutterPlugin = "flutter::https://github.com/asdf-community/asdf-flutter.git"
 
-func TestParseBitriseYml(t *testing.T) {
+func TestParseTools(t *testing.T) {
 	tests := []struct {
 		name     string
 		ymlPath  string
@@ -81,6 +81,41 @@ func TestParseBitriseYml(t *testing.T) {
 					t.Fatalf("%s: expected plugin identifier %s, got %s", key, *expected.PluginIdentifier, *actual.PluginIdentifier)
 				}
 			}
+		})
+	}
+}
+
+func TestParseToolConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		ymlPath  string
+		expected config.ToolConfig
+	}{
+		{
+			name:    "No explicit config",
+			ymlPath: "testdata/valid.bitrise.yml",
+			expected: config.ToolConfig{
+				Provider: "asdf",
+			},
+		},
+		{
+			name:    "Custom tool config",
+			ymlPath: "testdata/custom_config.bitrise.yml",
+			expected: config.ToolConfig{
+				Provider: "asdf",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bitriseYml, err := config.ParseBitriseYml(tt.ymlPath)
+			assert.NoError(t, err)
+			assert.NotNil(t, bitriseYml)
+
+			toolConfig, err := config.ParseToolConfig(bitriseYml)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, toolConfig)
 		})
 	}
 }

--- a/config/testdata/custom_config.bitrise.yml
+++ b/config/testdata/custom_config.bitrise.yml
@@ -1,0 +1,14 @@
+format_version: "17"
+
+workflows: {}
+
+meta:
+  bitrise.io:
+    stack: osx-xcode-15.0.x
+  experimental:
+    tools:
+      golang: 1.16.3
+      nodejs: 20:installed
+      ruby: 3.2:latest
+    tool_config:
+      provider: asdf

--- a/config/toolconfig.go
+++ b/config/toolconfig.go
@@ -1,0 +1,5 @@
+package config
+
+type ToolConfig struct {
+	Provider string `yaml:"provider"`
+}

--- a/provider/asdf/activate.go
+++ b/provider/asdf/activate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bitrise-io/toolprovider/provider"
 )
 
-func (a *AsdfToolProvider) ActivateEnv(result provider.ToolInstallResult) (provider.EnvironmentActivation, error) {
+func (a AsdfToolProvider) ActivateEnv(result provider.ToolInstallResult) (provider.EnvironmentActivation, error) {
 	envKey := fmt.Sprint("ASDF_", strings.ToUpper(result.ToolName), "_VERSION")
 	return provider.EnvironmentActivation{
 		ContributedEnvVars: map[string]string{

--- a/provider/asdf/asdf.go
+++ b/provider/asdf/asdf.go
@@ -19,7 +19,11 @@ type AsdfToolProvider struct {
 	ExecEnv execenv.ExecEnv
 }
 
-func (a *AsdfToolProvider) Bootstrap() error {
+func (a AsdfToolProvider) ID() string {
+	return "asdf"
+}
+
+func (a AsdfToolProvider) Bootstrap() error {
 	// TODO:
 	// Check if asdf is installed
 	// Check if asdf version satisfies the supported version range
@@ -27,7 +31,7 @@ func (a *AsdfToolProvider) Bootstrap() error {
 	return nil
 }
 
-func (a *AsdfToolProvider) InstallTool(tool provider.ToolRequest) (provider.ToolInstallResult, error) {
+func (a AsdfToolProvider) InstallTool(tool provider.ToolRequest) (provider.ToolInstallResult, error) {
 	err := a.InstallPlugin(tool)
 	if err != nil {
 		return provider.ToolInstallResult{}, fmt.Errorf("install tool plugin %s: %w", tool.ToolName, err)

--- a/provider/asdf/install_plugin.go
+++ b/provider/asdf/install_plugin.go
@@ -29,7 +29,7 @@ var pluginSourceMap = map[string]PluginSource{
 //
 // It resolves the plugin source from the tool request or predefined map,
 // checks if the plugin is already installed, and if not, installs it using asdf.
-func (a *AsdfToolProvider) InstallPlugin(tool provider.ToolRequest) error {
+func (a AsdfToolProvider) InstallPlugin(tool provider.ToolRequest) error {
 	plugin, err := fetchPluginSource(tool)
 	if err != nil {
 		// E.g. parse error while resolving plugin source.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -65,6 +65,8 @@ type EnvironmentActivation struct {
 }
 
 type ToolProvider interface {
+	ID() string
+
 	Bootstrap() error
 
 	InstallTool(tool ToolRequest) (ToolInstallResult, error)


### PR DESCRIPTION
Proposed API:
```yaml
meta:
  bitrise.io:
    stack: osx-xcode-15.0.x
  experimental:
    tools:
      golang: 1.16.3
      nodejs: 20:installed
      ruby: 3.2:latest
    tool_config:
      provider: asdf
```

This PR contains just the selection logic, nothing else yet. asdf remains the single and default provider.