### PR TITLE
mise: implement tool install

### DIFF
--- a/_integration_tests/mise/install_java_test.go
+++ b/_integration_tests/mise/install_java_test.go
@@ -1,0 +1,59 @@
+package mise
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/toolprovider/provider"
+	"github.com/bitrise-io/toolprovider/provider/mise"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiseInstallJavaVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		requestedVersion   string
+		resolutionStrategy provider.ResolutionStrategy
+		expectedVersion    string
+	}{
+		{
+			name:               "OpenJDK major version only",
+			requestedVersion:   "21",
+			resolutionStrategy: provider.ResolutionStrategyStrict,
+			expectedVersion:    "21.0.2",
+		},
+		{
+			name:               "OpenJDK major version only, latest released",
+			requestedVersion:   "17",
+			resolutionStrategy: provider.ResolutionStrategyLatestReleased,
+			expectedVersion:    "17.0.2",
+		},
+		{
+			name:               "Temurin major version only",
+			requestedVersion:   "temurin-21",
+			resolutionStrategy: provider.ResolutionStrategyLatestReleased,
+			expectedVersion:    "temurin-21.0.7+6.0.LTS",
+		},
+		{
+			name:               "Temurin exact version",
+			requestedVersion:   "temurin-17.0.8+101",
+			resolutionStrategy: provider.ResolutionStrategyStrict,
+			expectedVersion:    "temurin-17.0.8+101",
+		},
+	}
+
+	for _, tt := range tests {
+		miseProvider := mise.MiseToolProvider{}
+		t.Run(tt.name, func(t *testing.T) {
+			request := provider.ToolRequest{
+				ToolName:           "java",
+				UnparsedVersion:    tt.requestedVersion,
+				ResolutionStrategy: tt.resolutionStrategy,
+			}
+			result, err := miseProvider.InstallTool(request)
+			require.NoError(t, err)
+			require.Equal(t, "java", result.ToolName)
+			require.Equal(t, tt.expectedVersion, result.ConcreteVersion)
+			require.False(t, result.IsAlreadyInstalled)
+		})
+	}
+}

--- a/_integration_tests/mise/install_nodejs_test.go
+++ b/_integration_tests/mise/install_nodejs_test.go
@@ -1,0 +1,38 @@
+package mise
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/toolprovider/provider"
+	"github.com/bitrise-io/toolprovider/provider/mise"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiseInstallNodeVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		requestedVersion   string
+		resolutionStrategy provider.ResolutionStrategy
+		expectedVersion    string
+	}{
+		{"Install specific version", "18.16.0", provider.ResolutionStrategyStrict, "18.16.0"},
+		{"Install partial major version", "20", provider.ResolutionStrategyLatestInstalled, "20.19.3"},
+		{"Install partial major.minor version", "18.10", provider.ResolutionStrategyLatestReleased, "18.10.0"},
+	}
+
+	for _, tt := range tests {
+		miseProvider := mise.MiseToolProvider{}
+		t.Run(tt.name, func(t *testing.T) {
+			request := provider.ToolRequest{
+				ToolName:           "nodejs",
+				UnparsedVersion:    tt.requestedVersion,
+				ResolutionStrategy: tt.resolutionStrategy,
+			}
+			result, err := miseProvider.InstallTool(request)
+			require.NoError(t, err)
+			require.Equal(t, "nodejs", result.ToolName)
+			require.Equal(t, tt.expectedVersion, result.ConcreteVersion)
+			require.False(t, result.IsAlreadyInstalled)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
 	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
+	"github.com/bitrise-io/toolprovider/provider/mise"
 )
 
 func main() {
@@ -41,6 +42,8 @@ func main() {
 				ShellInit: "", // TODO
 			},
 		}
+	case "mise":
+		toolProvider = &mise.MiseToolProvider{}
 	default:
 		panic(fmt.Errorf("unsupported tool provider: %s", toolConfig.Provider))
 	}

--- a/provider/mise/install.go
+++ b/provider/mise/install.go
@@ -1,0 +1,75 @@
+package mise
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/bitrise-io/toolprovider/provider"
+)
+
+func (m *MiseToolProvider) installToolVersion(tool provider.ToolRequest) error {
+	versionString, err := miseVersionString(tool, m.resolveToLatestInstalled)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("mise", "install", "--yes", versionString)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return provider.ToolInstallError{
+			ToolName:         tool.ToolName,
+			RequestedVersion: versionString,
+			Cause:            fmt.Sprintf("mise install %s@%s: %s", tool.ToolName, versionString, err),
+			RawOutput:        string(output),
+		}
+	}
+	return nil
+}
+
+// Helper for easier testing.
+// Inputs: tool name, tool version
+// Returns: latest installed version of the tool, or an error if no matching version is installed
+type latestInstalledResolver func(string, string) (string, error)
+
+func isAlreadyInstalled(tool provider.ToolRequest, latestInstalledResolver latestInstalledResolver) (bool, error) {
+	_, err := latestInstalledResolver(tool.ToolName, tool.UnparsedVersion)
+	var isAlreadyInstalled bool
+	if err != nil {
+		if errors.Is(err, errNoMatchingVersion) {
+			isAlreadyInstalled = false
+		} else {
+			return false, err
+		}
+	} else {
+		isAlreadyInstalled = true
+	}
+	return isAlreadyInstalled, nil
+}
+
+func miseVersionString(tool provider.ToolRequest, latestInstalledResolver latestInstalledResolver) (string, error) {
+	var miseVersionString string
+	switch tool.ResolutionStrategy {
+	case provider.ResolutionStrategyStrict:
+		miseVersionString = fmt.Sprintf("%s@%s", tool.ToolName, tool.UnparsedVersion)
+	case provider.ResolutionStrategyLatestReleased:
+		// https://mise.jdx.dev/configuration.html#scopes
+		miseVersionString = fmt.Sprintf("%s@prefix:%s", tool.ToolName, tool.UnparsedVersion)
+	case provider.ResolutionStrategyLatestInstalled:
+		latestInstalledV, err := latestInstalledResolver(tool.ToolName, tool.UnparsedVersion)
+		if err == nil {
+			miseVersionString = fmt.Sprintf("%s@%s", tool.ToolName, latestInstalledV)
+		} else {
+			if errors.Is(err, errNoMatchingVersion) {
+				// No local version satisfies the request -> fallback to latest released
+				miseVersionString = fmt.Sprintf("%s@prefix:%s", tool.ToolName, tool.UnparsedVersion)
+			} else {
+				return "", fmt.Errorf("resolve %s %s to latest installed version: %w", tool.ToolName, tool.UnparsedVersion, err)
+			}
+		}
+	default:
+		return "", fmt.Errorf("unknown resolution strategy: %v", tool.ResolutionStrategy)
+	}
+	return miseVersionString, nil
+
+}

--- a/provider/mise/install_test.go
+++ b/provider/mise/install_test.go
@@ -1,0 +1,172 @@
+package mise
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bitrise-io/toolprovider/provider"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiseVersionString(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    provider.ToolRequest
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "strict resolution strategy, exact version",
+			tool: provider.ToolRequest{
+				ToolName:           "node",
+				UnparsedVersion:    "18.20.0",
+				ResolutionStrategy: provider.ResolutionStrategyStrict,
+			},
+			want:    "node@18.20.0",
+			wantErr: false,
+		},
+		{
+			name: "latest released resolution strategy, partial version",
+			tool: provider.ToolRequest{
+				ToolName:           "python",
+				UnparsedVersion:    "3.11",
+				ResolutionStrategy: provider.ResolutionStrategyLatestReleased,
+			},
+			want:    "python@prefix:3.11",
+			wantErr: false,
+		},
+		{
+			name: "latest installed resolution strategy, partial version, version found",
+			tool: provider.ToolRequest{
+				ToolName:           "go",
+				UnparsedVersion:    "1.21",
+				ResolutionStrategy: provider.ResolutionStrategyLatestInstalled,
+			},
+			want:    "go@1.21.5",
+			wantErr: false,
+		},
+		{
+			name: "latest installed resolution strategy, no version found, fallback to latest released",
+			tool: provider.ToolRequest{
+				ToolName:           "java",
+				UnparsedVersion:    "17",
+				ResolutionStrategy: provider.ResolutionStrategyLatestInstalled,
+			},
+			want:    "java@prefix:17",
+			wantErr: false,
+		},
+		{
+			name: "latest installed resolution strategy - error resolving",
+			tool: provider.ToolRequest{
+				ToolName:           "ruby",
+				UnparsedVersion:    "3.0",
+				ResolutionStrategy: provider.ResolutionStrategyLatestInstalled,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "unknown resolution strategy",
+			tool: provider.ToolRequest{
+				ToolName:           "node",
+				UnparsedVersion:    "18.0.0",
+				ResolutionStrategy: provider.ResolutionStrategy(999),
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			latestInstalledResolver := func(toolName, version string) (string, error) {
+				// Setup fake behavior based on test case
+				switch tt.tool.ToolName {
+				case "go":
+					// Fake successful resolution
+					return "1.21.5", nil
+				case "java":
+					// Fake no matching version found
+					return "", errNoMatchingVersion
+				case "ruby":
+					// Fake other error
+					return "", errors.New("some other error")
+				}
+				return "", fmt.Errorf("no fake behavior defined for tool %s", toolName)
+			}
+
+			got, err := miseVersionString(tt.tool, latestInstalledResolver)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyInstalled(t *testing.T) {
+	tests := []struct {
+		name                 string
+		tool                 provider.ToolRequest
+		latestInstalledError error
+		want                 bool
+		wantErr              bool
+	}{
+		{
+			name: "tool is already installed",
+			tool: provider.ToolRequest{
+				ToolName:        "node",
+				UnparsedVersion: "18.20.0",
+			},
+			latestInstalledError: nil,
+			want:                 true,
+			wantErr:              false,
+		},
+		{
+			name: "tool is not installed - no matching version",
+			tool: provider.ToolRequest{
+				ToolName:        "python",
+				UnparsedVersion: "3.11",
+			},
+			latestInstalledError: errNoMatchingVersion,
+			want:                 false,
+			wantErr:              false,
+		},
+		{
+			name: "error resolving installed versions",
+			tool: provider.ToolRequest{
+				ToolName:        "ruby",
+				UnparsedVersion: "3.0",
+			},
+			latestInstalledError: errors.New("failed to list installed versions"),
+			want:                 false,
+			wantErr:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			latestInstalledResolver := func(toolName, version string) (string, error) {
+				if tt.latestInstalledError != nil {
+					return "", tt.latestInstalledError
+				}
+				return "fake.version", nil
+			}
+
+			got, err := isAlreadyInstalled(tt.tool, latestInstalledResolver)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.False(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/provider/mise/mise.go
+++ b/provider/mise/mise.go
@@ -1,0 +1,50 @@
+package mise
+
+import (
+	"fmt"
+
+	"github.com/bitrise-io/toolprovider/provider"
+)
+
+type MiseToolProvider struct {
+
+}
+
+
+func (m *MiseToolProvider) ID() string {
+	return "mise"
+}
+
+
+func (m *MiseToolProvider) Bootstrap() error {
+	// TODO
+	return nil
+}
+
+func (m *MiseToolProvider) InstallTool(tool provider.ToolRequest) (provider.ToolInstallResult, error) {
+	isAlreadyInstalled, err := isAlreadyInstalled(tool, m.resolveToLatestInstalled)
+	if err != nil {
+		return provider.ToolInstallResult{}, err
+	}
+
+	err = m.installToolVersion(tool)
+	if err != nil {
+		return provider.ToolInstallResult{}, err
+	}
+
+	concreteVersion, err := m.resolveToConcreteVersionAfterInstall(tool)
+	if err != nil {
+		return provider.ToolInstallResult{}, fmt.Errorf("resolve exact version after install: %w", err)
+	}
+
+	return provider.ToolInstallResult{
+		ToolName:        tool.ToolName,
+		IsAlreadyInstalled: isAlreadyInstalled,
+		ConcreteVersion: concreteVersion,
+	}, nil
+}
+
+func (m *MiseToolProvider) ActivateEnv(result provider.ToolInstallResult) (provider.EnvironmentActivation, error) {
+	// TODO
+	return provider.EnvironmentActivation{}, nil
+}

--- a/provider/mise/resolve.go
+++ b/provider/mise/resolve.go
@@ -1,0 +1,58 @@
+package mise
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/bitrise-io/toolprovider/provider"
+)
+
+var errNoMatchingVersion = errors.New("no matching version found")
+
+func (m *MiseToolProvider) resolveToConcreteVersionAfterInstall(tool provider.ToolRequest) (string, error) {
+	// Mise doesn't tell us what version it resolved to when installing the user-provided (and potentially fuzzy) version.
+	// But we can use `mise latest` to find out the concrete version.
+	switch tool.ResolutionStrategy {
+	case provider.ResolutionStrategyLatestInstalled:
+		return m.resolveToLatestInstalled(tool.ToolName, tool.UnparsedVersion)
+	case provider.ResolutionStrategyLatestReleased, provider.ResolutionStrategyStrict:
+		// Mise works with fuzzy versions by default, so it happily installs both node@20 and node@20.19.3.
+		// Therefore, when the Bitrise config contains simply 20 (and not 20:latest), it actually behaves
+		// as "latest released".
+		return m.resolveToLatestReleased(tool.ToolName, tool.UnparsedVersion)
+	default:
+		return "", fmt.Errorf("unknown resolution strategy: %v", tool.ResolutionStrategy)
+	}
+}
+
+func (m *MiseToolProvider) resolveToLatestReleased(toolName string, version string) (string, error) {
+	cmd := exec.Command("mise", "latest", fmt.Sprintf("%s@%s", toolName, version))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("mise latest %s@%s: %w", toolName, version, err)
+	}
+
+	v := strings.TrimSpace(string(output))
+	if v == "" {
+		return "", errNoMatchingVersion
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (m *MiseToolProvider) resolveToLatestInstalled(toolName string, version string) (string, error) {
+	cmd := exec.Command("mise", "latest", "--installed", fmt.Sprintf("%s@%s", toolName, version))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("mise latest --installed %s@%s: %w", toolName, version, err)
+	}
+
+	v := strings.TrimSpace(string(output))
+	if v == "" {
+		return "", errNoMatchingVersion
+	}
+
+	return v, nil
+}


### PR DESCRIPTION
Create the skeleton of `MiseToolProvider` and implement the tool install feature.

Testing: it requires a system-wide Mise install for now.

Mise basically handles partial versions exactly as our "latest released" strategy, I verified that e.g. `mise install node@20` always installs the latest available release, even if one (earlier) Node 20.x version is already installed. Therefore, our "latest released" strategy is easy to implement, but the "latest installed" strategy requires a bit more work (see `resolve.go`)

https://mise.jdx.dev/configuration.html#scopes

One more interesting detail is that `mise install node@20` doesn't return what exact version this resolved to, and I couldn't find a way to query this information after the install either. Therefore, we have `resolveToConcreteVersionAfterInstall()`, which is a bit awkward as it uses the logic described above. I'm not sure how I feel about this.