### PR TITLE
mise: implement activate env

### DIFF
--- a/provider/mise/env.go
+++ b/provider/mise/env.go
@@ -1,0 +1,63 @@
+package mise
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/bitrise-io/toolprovider/provider"
+)
+
+type envOutput map[string]string
+
+// envVarsForTool returns the env vars required for the given tool version to be available and work correctly in
+// a shell environment. This includes $PATH additions and other env vars, such as $JAVA_HOME, $GOROOT, etc.
+func (m *MiseToolProvider) envVarsForTool(installResult provider.ToolInstallResult) (envOutput, error) {
+	// Note: --quiet hides warnings and other plain text lines that would break JSON parsing.
+	envCmd := exec.Command("mise", "env", "--quiet", "--json", fmt.Sprintf("%s@%s", installResult.ToolName, installResult.ConcreteVersion))
+	data, err := envCmd.CombinedOutput()
+	if err != nil {
+		return envOutput{}, fmt.Errorf("mise env %s@%s: %w", installResult.ToolName, installResult.ConcreteVersion, err)
+	}
+
+	var env envOutput
+	err = json.Unmarshal(data, &env)
+	if err != nil {
+		return envOutput{}, fmt.Errorf("parse mise env output: %w\n%s", err, string(data))
+	}
+
+	return env, nil
+}
+
+func processEnvOutput(envs envOutput) provider.EnvironmentActivation {
+	// `mise env` returns tool-specific envs, as well as a new $PATH with the tool-specific dirs prepended.
+	envsWithoutPath := maps.Clone(envs)
+	delete(envsWithoutPath, "PATH")
+
+	var pathsAddedByMise []string
+	pathEnv, exists := envs["PATH"]
+	if exists && pathEnv != "" {
+		misePaths := strings.Split(pathEnv, ":")
+		processPathEnv := os.Getenv("PATH")
+		processPaths := strings.Split(processPathEnv, ":")
+
+		// Track paths we've already added to avoid duplicates
+		addedPaths := make(map[string]bool)
+		for _, p := range misePaths {
+			if p != "" && !slices.Contains(processPaths, p) && !addedPaths[p] {
+				pathsAddedByMise = append(pathsAddedByMise, p)
+				addedPaths[p] = true
+			}
+		}
+	}
+
+	return provider.EnvironmentActivation{
+		ContributedEnvVars: envsWithoutPath,
+		ContributedPaths:   pathsAddedByMise,
+	}
+}

--- a/provider/mise/env_test.go
+++ b/provider/mise/env_test.go
@@ -1,0 +1,146 @@
+package mise
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessEnvs(t *testing.T) {
+	tests := []struct {
+		name                     string
+		envs                     envOutput
+		currentPath              string
+		expectedContributedVars  map[string]string
+		expectedContributedPaths []string
+	}{
+		{
+			name:                     "empty envs",
+			envs:                     envOutput{},
+			currentPath:              "/usr/bin:/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: nil,
+		},
+		{
+			name: "only non-PATH env vars",
+			envs: envOutput{
+				"NODE_ENV":    "production",
+				"JAVA_HOME":   "/opt/java",
+				"PYTHON_PATH": "/opt/python/lib",
+			},
+			currentPath: "/usr/bin:/bin",
+			expectedContributedVars: map[string]string{
+				"NODE_ENV":    "production",
+				"JAVA_HOME":   "/opt/java",
+				"PYTHON_PATH": "/opt/python/lib",
+			},
+			expectedContributedPaths: nil,
+		},
+		{
+			name: "PATH with new directories",
+			envs: envOutput{
+				"PATH": "/opt/mise/bin:/opt/tool/bin:/usr/bin:/bin",
+			},
+			currentPath:              "/usr/bin:/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: []string{"/opt/mise/bin", "/opt/tool/bin"},
+		},
+		{
+			name: "PATH with no new directories",
+			envs: envOutput{
+				"PATH": "/usr/bin:/bin",
+			},
+			currentPath:              "/usr/bin:/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: nil,
+		},
+		{
+			name: "PATH with some new and some existing directories",
+			envs: envOutput{
+				"PATH": "/opt/mise/bin:/usr/bin:/opt/tool/bin:/bin",
+			},
+			currentPath:              "/usr/bin:/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: []string{"/opt/mise/bin", "/opt/tool/bin"},
+		},
+		{
+			name: "mixed env vars and PATH",
+			envs: envOutput{
+				"NODE_ENV":  "development",
+				"PATH":      "/opt/node/bin:/usr/bin:/bin",
+				"JAVA_HOME": "/opt/java",
+			},
+			currentPath: "/usr/bin:/bin",
+			expectedContributedVars: map[string]string{
+				"NODE_ENV":  "development",
+				"JAVA_HOME": "/opt/java",
+			},
+			expectedContributedPaths: []string{"/opt/node/bin"},
+		},
+		{
+			name: "PATH with empty current PATH",
+			envs: envOutput{
+				"PATH": "/opt/mise/bin:/opt/tool/bin",
+			},
+			currentPath:              "",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: []string{"/opt/mise/bin", "/opt/tool/bin"},
+		},
+		{
+			name: "empty PATH in envs",
+			envs: envOutput{
+				"PATH":     "",
+				"NODE_ENV": "test",
+			},
+			currentPath: "/usr/bin:/bin",
+			expectedContributedVars: map[string]string{
+				"NODE_ENV": "test",
+			},
+			expectedContributedPaths: nil,
+		},
+		{
+			name: "PATH with single directory",
+			envs: envOutput{
+				"PATH": "/opt/tool/bin",
+			},
+			currentPath:              "/usr/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: []string{"/opt/tool/bin"},
+		},
+		{
+			name: "duplicate paths should not be added",
+			envs: envOutput{
+				"PATH": "/opt/new/bin:/usr/bin:/opt/new/bin:/bin",
+			},
+			currentPath:              "/usr/bin:/bin",
+			expectedContributedVars:  map[string]string{},
+			expectedContributedPaths: []string{"/opt/new/bin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the current PATH environment
+			t.Setenv("PATH", tt.currentPath)
+
+			result := processEnvOutput(tt.envs)
+
+			require.Equal(t, tt.expectedContributedVars, result.ContributedEnvVars, "ContributedEnvVars should match")
+			require.Equal(t, tt.expectedContributedPaths, result.ContributedPaths, "ContributedPaths should match")
+		})
+	}
+}
+
+func TestProcessEnvs_PreservesOrder(t *testing.T) {
+	// Test that the order of contributed paths is preserved (first paths in mise PATH that are not in current PATH)
+	envs := envOutput{
+		"PATH": "/first/bin:/second/bin:/usr/bin:/third/bin:/bin",
+	}
+
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	result := processEnvOutput(envs)
+
+	expectedPaths := []string{"/first/bin", "/second/bin", "/third/bin"}
+	require.Equal(t, expectedPaths, result.ContributedPaths, "Order of contributed paths should be preserved")
+}

--- a/provider/mise/mise.go
+++ b/provider/mise/mise.go
@@ -7,14 +7,11 @@ import (
 )
 
 type MiseToolProvider struct {
-
 }
-
 
 func (m *MiseToolProvider) ID() string {
 	return "mise"
 }
-
 
 func (m *MiseToolProvider) Bootstrap() error {
 	// TODO
@@ -38,13 +35,17 @@ func (m *MiseToolProvider) InstallTool(tool provider.ToolRequest) (provider.Tool
 	}
 
 	return provider.ToolInstallResult{
-		ToolName:        tool.ToolName,
+		ToolName:           tool.ToolName,
 		IsAlreadyInstalled: isAlreadyInstalled,
-		ConcreteVersion: concreteVersion,
+		ConcreteVersion:    concreteVersion,
 	}, nil
 }
 
 func (m *MiseToolProvider) ActivateEnv(result provider.ToolInstallResult) (provider.EnvironmentActivation, error) {
-	// TODO
-	return provider.EnvironmentActivation{}, nil
+	envs, err := m.envVarsForTool(result)
+	if err != nil {
+		return provider.EnvironmentActivation{}, fmt.Errorf("get mise env: %w", err)
+	}
+
+	return processEnvOutput(envs), nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -59,6 +59,8 @@ func (e ToolInstallError) Error() string {
 	return msg
 }
 
+// TODO: Mise merges envs and $PATH changes into one output, maybe we should do the same for asdf?
+// It would simplify the activation process.
 type EnvironmentActivation struct {
 	ContributedEnvVars map[string]string
 	ContributedPaths   []string


### PR DESCRIPTION
Env activation is similar to asdf, it's just env vars and new `$PATH` additions. The difference is that Mise doesn't need a new subshell and sourcing of helper scripts in order to activate the right version of a tool. It has [multiple, well-documented activation methods](https://mise.jdx.dev/dev-tools/shims.html#overview). The most ergonomic activation method for our use-case is I think `mise env tool@version`, which returns all env vars:

```
❯ mise env go@1.24 --json --quiet
{
  "GOBIN": "/Users/oliverfalvai/.local/share/mise/installs/go/1.24.5/bin",
  "GOROOT": "/Users/oliverfalvai/.local/share/mise/installs/go/1.24.5",
  "PATH": "/Users/oliverfalvai/.local/share/mise/installs/go/1.24.5/bin:/Users/oliverfalvai/.asdf/shims:/Users/oliverfalvai/.asdf/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Applications/Xcode-26.0.0-beta.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:/Users/oliverfalvai/.codeium/windsurf/bin:/Users/oliverfalvai/Library/Android/sdk/cmdline-tools/latest/bin:/Users/oliverfalvai/Library/Android/sdk/platform-tools:/Users/oliverfalvai/Library/Android/sdk/emulator:/Users/oliverfalvai/.nix-profile/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/oliverfalvai/.orbstack/bin"
}
```