### PR TITLE
asdf: clear inherited envs in integration tests

### DIFF
--- a/_integration_tests/asdf/install_error_test.go
+++ b/_integration_tests/asdf/install_error_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
-	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,10 +17,7 @@ func TestNoMatchingVersionError(t *testing.T) {
 	require.NoError(t, err)
 
 	asdfProvider := asdf.AsdfToolProvider{
-		ExecEnv: execenv.ExecEnv{
-			EnvVars:   testEnv.envVars,
-			ShellInit: testEnv.shellInit,
-		},
+		ExecEnv: testEnv.toExecEnv(),
 	}
 	request := provider.ToolRequest{
 		ToolName:           "nodejs",
@@ -35,7 +31,7 @@ func TestNoMatchingVersionError(t *testing.T) {
 	require.ErrorAs(t, err, &installErr)
 	require.Equal(t, "nodejs", installErr.ToolName)
 	require.Equal(t, "22", installErr.RequestedVersion)
-	require.Contains(t, installErr.Error(), "No exact match found for 22")
+	require.Contains(t, installErr.Error(), "no match for requested version 22")
 	require.Contains(t, installErr.Recommendation, "22:latest")
 	require.Contains(t, installErr.Recommendation, "22:installed")
 }
@@ -49,10 +45,7 @@ func TestNewToolPluginError(t *testing.T) {
 	require.NoError(t, err)
 
 	asdfProvider := asdf.AsdfToolProvider{
-		ExecEnv: execenv.ExecEnv{
-			EnvVars:   testEnv.envVars,
-			ShellInit: testEnv.shellInit,
-		},
+		ExecEnv: testEnv.toExecEnv(),
 	}
 	request := provider.ToolRequest{
 		ToolName:           "foo",

--- a/_integration_tests/asdf/install_flutter_no_plugin_test.go
+++ b/_integration_tests/asdf/install_flutter_no_plugin_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
-	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,10 +28,7 @@ func TestAsdfInstallFlutterNoPlugin(t *testing.T) {
 		require.NoError(t, err)
 
 		asdfProvider := asdf.AsdfToolProvider{
-			ExecEnv: execenv.ExecEnv{
-				EnvVars:   testEnv.envVars,
-				ShellInit: testEnv.shellInit,
-			},
+			ExecEnv: testEnv.toExecEnv(),
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			request := provider.ToolRequest{

--- a/_integration_tests/asdf/install_golang_test.go
+++ b/_integration_tests/asdf/install_golang_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
-	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,10 +29,7 @@ func TestAsdfInstallGolangVersion(t *testing.T) {
 		require.NoError(t, err)
 
 		asdfProvider := asdf.AsdfToolProvider{
-			ExecEnv: execenv.ExecEnv{
-				EnvVars:   testEnv.envVars,
-				ShellInit: testEnv.shellInit,
-			},
+			ExecEnv: testEnv.toExecEnv(),
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			request := provider.ToolRequest{

--- a/_integration_tests/asdf/install_nodejs_test.go
+++ b/_integration_tests/asdf/install_nodejs_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
-	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +16,7 @@ func TestAsdfInstallNodeVersion(t *testing.T) {
 		expectedVersion    string
 	}{
 		{"Install specific version", "18.16.0", provider.ResolutionStrategyStrict, "18.16.0"},
-		{"Install partial major version", "20", provider.ResolutionStrategyLatestInstalled, "20.19.3"},
+		{"Install partial major version", "18", provider.ResolutionStrategyLatestInstalled, "18.20.8"},
 		{"Install partial major.minor version", "18.10", provider.ResolutionStrategyLatestReleased, "18.10.0"},
 	}
 
@@ -30,10 +29,7 @@ func TestAsdfInstallNodeVersion(t *testing.T) {
 		require.NoError(t, err)
 
 		asdfProvider := asdf.AsdfToolProvider{
-			ExecEnv: execenv.ExecEnv{
-				EnvVars:   testEnv.envVars,
-				ShellInit: testEnv.shellInit,
-			},
+			ExecEnv: testEnv.toExecEnv(),
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			request := provider.ToolRequest{
@@ -59,10 +55,7 @@ func TestCorepackWithNewNodeInstall(t *testing.T) {
 	require.NoError(t, err)
 
 	asdfProvider := asdf.AsdfToolProvider{
-		ExecEnv: execenv.ExecEnv{
-			EnvVars:   testEnv.envVars,
-			ShellInit: testEnv.shellInit,
-		},
+		ExecEnv: testEnv.toExecEnv(),
 	}
 	request := provider.ToolRequest{
 		ToolName:        "nodejs",

--- a/_integration_tests/asdf/install_test.go
+++ b/_integration_tests/asdf/install_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/toolprovider/provider"
 	"github.com/bitrise-io/toolprovider/provider/asdf"
-	"github.com/bitrise-io/toolprovider/provider/asdf/execenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,10 +17,7 @@ func TestAsdfInstallClassic(t *testing.T) {
 	require.NoError(t, err)
 
 	asdfProvider := asdf.AsdfToolProvider{
-		ExecEnv: execenv.ExecEnv{
-			EnvVars:   testEnv.envVars,
-			ShellInit: testEnv.shellInit,
-		},
+		ExecEnv: testEnv.toExecEnv(),
 	}
 
 	request := provider.ToolRequest{
@@ -44,10 +40,7 @@ func TestAsdfInstallRewrite(t *testing.T) {
 	require.NoError(t, err)
 
 	asdfProvider := asdf.AsdfToolProvider{
-		ExecEnv: execenv.ExecEnv{
-			EnvVars:   testEnv.envVars,
-			ShellInit: testEnv.shellInit,
-		},
+		ExecEnv: testEnv.toExecEnv(),
 	}
 
 	request := provider.ToolRequest{

--- a/provider/asdf/execenv/execenv.go
+++ b/provider/asdf/execenv/execenv.go
@@ -15,6 +15,9 @@ type ExecEnv struct {
 	// Env vars that confiure asdf and are required for its operation.
 	EnvVars map[string]string
 
+	// When set to true, env vars inherited from the parent process are cleared for maximum isolation.
+	ClearInheritedEnvs bool
+
 	// ShellInit is a shell command that initializes asdf in the shell session.
 	// This is required because classic asdf is written in bash and we can't assume that
 	// its init command is sourced in .bashrc or similar (and we don't want to modify
@@ -43,7 +46,9 @@ func (e *ExecEnv) RunCommand(extraEnvs map[string]string, args ...string) (strin
 	// relies on shell features.
 	bashArgs := []string{"-c", strings.Join(innerShellCmd, " ")}
 	bashCmd := exec.Command("bash", bashArgs...)
-	bashCmd.Env = os.Environ()
+	if !e.ClearInheritedEnvs {
+		bashCmd.Env = os.Environ()
+	}
 	for k, v := range e.EnvVars {
 		bashCmd.Env = append(bashCmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/provider/asdf/resolve.go
+++ b/provider/asdf/resolve.go
@@ -29,7 +29,7 @@ func (e ErrNoMatchingVersion) Error() string {
 	if versionList == "" {
 		return fmt.Sprintf("no match for requested version %s", e.RequestedVersion)
 	} else {
-		return fmt.Sprintf("no match for %s. Similar versions: \n%s", e.RequestedVersion, versionList)
+		return fmt.Sprintf("no match for requested version %s. Similar versions: \n%s", e.RequestedVersion, versionList)
 	}
 }
 


### PR DESCRIPTION
Found some potential bugs while working on Mise testing. Luckily, it didn't manifest in hidden test failures.