### PR TITLE
mise: implement bootstrap, isolate from system-wide environment

### DIFF
--- a/_integration_tests/mise/install_java_test.go
+++ b/_integration_tests/mise/install_java_test.go
@@ -29,20 +29,27 @@ func TestMiseInstallJavaVersion(t *testing.T) {
 		},
 		{
 			name:               "Temurin major version only",
-			requestedVersion:   "temurin-21",
+			requestedVersion:   "temurin-22",
 			resolutionStrategy: provider.ResolutionStrategyLatestReleased,
-			expectedVersion:    "temurin-21.0.7+6.0.LTS",
+			expectedVersion:    "temurin-22.0.2+9",
 		},
 		{
 			name:               "Temurin exact version",
-			requestedVersion:   "temurin-17.0.8+101",
+			requestedVersion:   "temurin-18.0.2+9",
 			resolutionStrategy: provider.ResolutionStrategyStrict,
-			expectedVersion:    "temurin-17.0.8+101",
+			expectedVersion:    "temurin-18.0.2+9",
 		},
 	}
 
 	for _, tt := range tests {
-		miseProvider := mise.MiseToolProvider{}
+		miseInstallDir := t.TempDir()
+		miseDataDir := t.TempDir()
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir)
+		require.NoError(t, err)
+
+		err = miseProvider.Bootstrap()
+		require.NoError(t, err)
+
 		t.Run(tt.name, func(t *testing.T) {
 			request := provider.ToolRequest{
 				ToolName:           "java",

--- a/_integration_tests/mise/install_nodejs_test.go
+++ b/_integration_tests/mise/install_nodejs_test.go
@@ -16,12 +16,19 @@ func TestMiseInstallNodeVersion(t *testing.T) {
 		expectedVersion    string
 	}{
 		{"Install specific version", "18.16.0", provider.ResolutionStrategyStrict, "18.16.0"},
-		{"Install partial major version", "20", provider.ResolutionStrategyLatestInstalled, "20.19.3"},
+		{"Install partial major version", "18", provider.ResolutionStrategyLatestInstalled, "18.20.8"},
 		{"Install partial major.minor version", "18.10", provider.ResolutionStrategyLatestReleased, "18.10.0"},
 	}
 
 	for _, tt := range tests {
-		miseProvider := mise.MiseToolProvider{}
+		miseInstallDir := t.TempDir()
+		miseDataDir := t.TempDir()
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir)
+		require.NoError(t, err)
+
+		err = miseProvider.Bootstrap()
+		require.NoError(t, err)
+
 		t.Run(tt.name, func(t *testing.T) {
 			request := provider.ToolRequest{
 				ToolName:           "nodejs",

--- a/provider/mise/bootstrap.go
+++ b/provider/mise/bootstrap.go
@@ -1,0 +1,160 @@
+package mise
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+func installReleaseBinary(version string, targetDir string) error {
+	url, err := downloadURL(version)
+	if err != nil {
+		return err
+	}
+
+	resp, err := retryablehttp.Get(url)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: received status code %d", url, resp.StatusCode)
+	}
+
+	gzipReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer func() {
+		_ = gzipReader.Close()
+	}()
+
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", targetDir, err)
+	}
+
+	tarReader := tar.NewReader(gzipReader)
+	var miseBinFound bool
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar header: %w", err)
+		}
+
+		if extractedPath, shouldExtract := processHeader(header, targetDir); shouldExtract {
+			if err := extractFile(tarReader, header, extractedPath); err != nil {
+				return err
+			}
+			if filepath.Base(extractedPath) == "mise" {
+				miseBinFound = true
+			}
+		}
+	}
+
+	if !miseBinFound {
+		return fmt.Errorf("mise binary not found in tarball from %s", url)
+	}
+
+	return nil
+}
+
+func downloadURL(version string) (string, error) {
+	osMap := map[string]string{
+		"darwin": "macos",
+		"linux":  "linux",
+	}
+	archMap := map[string]string{
+		"amd64": "x64",
+		"arm64": "arm64",
+	}
+
+	osString, ok := osMap[runtime.GOOS]
+	if !ok {
+		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+
+	archString, ok := archMap[runtime.GOARCH]
+	if !ok {
+		return "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+	version = strings.TrimPrefix(version, "v")
+	artifactName := fmt.Sprintf("mise-v%s-%s-%s.tar.gz", version, osString, archString)
+	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/%s", version, artifactName)
+	return url, nil
+}
+
+func processHeader(header *tar.Header, targetDir string) (string, bool) {
+	// Skip the top-level "mise" directory and extract its contents directly
+	pathParts := strings.Split(header.Name, "/")
+	if len(pathParts) > 0 && pathParts[0] == "mise" {
+		if len(pathParts) == 1 {
+			// This is the top-level "mise" directory itself, skip it
+			return "", false
+		}
+		// Remove the top-level "mise" directory from the path
+		header.Name = strings.Join(pathParts[1:], "/")
+	}
+
+	// Clean the path to prevent directory traversal attacks
+	targetPath := filepath.Join(targetDir, header.Name)
+	if !strings.HasPrefix(targetPath, filepath.Clean(targetDir)) {
+		return "", false
+	}
+
+	return targetPath, true
+}
+
+func extractFile(tarReader *tar.Reader, header *tar.Header, targetPath string) error {
+	switch header.Typeflag {
+	case tar.TypeDir:
+		err := os.MkdirAll(targetPath, 0755)
+		if err != nil {
+			return fmt.Errorf("create directory %s: %w", targetPath, err)
+		}
+	case tar.TypeReg:
+		dir := filepath.Dir(targetPath)
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return fmt.Errorf("create parent directory for %s: %w", targetPath, err)
+		}
+
+		outFile, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
+		if err != nil {
+			return fmt.Errorf("create file %s: %w", targetPath, err)
+		}
+		defer func() {
+			_ = outFile.Close()
+		}()
+
+		_, err = io.Copy(outFile, tarReader)
+		if err != nil {
+			return fmt.Errorf("extract file %s: %w", targetPath, err)
+		}
+
+		if filepath.Base(targetPath) == "mise" {
+			// Make mise binary executable
+			err = os.Chmod(targetPath, 0755)
+			if err != nil {
+				return fmt.Errorf("make mise binary executable %s: %w", targetPath, err)
+			}
+		}
+	default:
+		// Skip other file types (symlinks, etc.)
+	}
+	return nil
+}

--- a/provider/mise/env.go
+++ b/provider/mise/env.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"slices"
 	"strings"
 
@@ -19,14 +18,13 @@ type envOutput map[string]string
 // a shell environment. This includes $PATH additions and other env vars, such as $JAVA_HOME, $GOROOT, etc.
 func (m *MiseToolProvider) envVarsForTool(installResult provider.ToolInstallResult) (envOutput, error) {
 	// Note: --quiet hides warnings and other plain text lines that would break JSON parsing.
-	envCmd := exec.Command("mise", "env", "--quiet", "--json", fmt.Sprintf("%s@%s", installResult.ToolName, installResult.ConcreteVersion))
-	data, err := envCmd.CombinedOutput()
+	data, err := m.ExecEnv.RunMise("env", "--quiet", "--json", fmt.Sprintf("%s@%s", installResult.ToolName, installResult.ConcreteVersion))
 	if err != nil {
 		return envOutput{}, fmt.Errorf("mise env %s@%s: %w", installResult.ToolName, installResult.ConcreteVersion, err)
 	}
 
 	var env envOutput
-	err = json.Unmarshal(data, &env)
+	err = json.Unmarshal([]byte(data), &env)
 	if err != nil {
 		return envOutput{}, fmt.Errorf("parse mise env output: %w\n%s", err, string(data))
 	}

--- a/provider/mise/execenv/execenv.go
+++ b/provider/mise/execenv/execenv.go
@@ -1,0 +1,33 @@
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// ExecEnv contains everything needed to run mise commands in a specific environment
+// that is installed and pre-configured.
+type ExecEnv struct {
+	// InstallDir is the directory where mise is installed. This is not necessarily the same as the data directory.
+	InstallDir string
+
+	// Additional env vars that configure mise and are required for its operation.
+	ExtraEnvs map[string]string
+}
+
+func (e *ExecEnv) RunMise(args ...string) (string, error) {
+	executable := path.Join(e.InstallDir, "bin", "mise")
+	cmd := exec.Command(executable, args...)
+	cmd.Env = os.Environ()
+	for k, v := range e.ExtraEnvs {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s\n%s", err, output)
+	}
+
+	return string(output), nil
+}

--- a/provider/mise/install.go
+++ b/provider/mise/install.go
@@ -3,7 +3,6 @@ package mise
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 
 	"github.com/bitrise-io/toolprovider/provider"
 )
@@ -14,13 +13,12 @@ func (m *MiseToolProvider) installToolVersion(tool provider.ToolRequest) error {
 		return err
 	}
 
-	cmd := exec.Command("mise", "install", "--yes", versionString)
-	output, err := cmd.CombinedOutput()
+	output, err := m.ExecEnv.RunMise("install", "--yes", versionString)
 	if err != nil {
 		return provider.ToolInstallError{
 			ToolName:         tool.ToolName,
 			RequestedVersion: versionString,
-			Cause:            fmt.Sprintf("mise install %s@%s: %s", tool.ToolName, versionString, err),
+			Cause:            fmt.Sprintf("mise install %s: %s", versionString, err),
 			RawOutput:        string(output),
 		}
 	}

--- a/provider/mise/resolve.go
+++ b/provider/mise/resolve.go
@@ -3,7 +3,6 @@ package mise
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/bitrise-io/toolprovider/provider"
@@ -29,8 +28,7 @@ func (m *MiseToolProvider) resolveToConcreteVersionAfterInstall(tool provider.To
 
 func (m *MiseToolProvider) resolveToLatestReleased(toolName string, version string) (string, error) {
 	// Even if version is empty string "sometool@" will not cause an error.
-	cmd := exec.Command("mise", "latest", fmt.Sprintf("%s@%s", toolName, version))
-	output, err := cmd.CombinedOutput()
+	output, err := m.ExecEnv.RunMise("latest", fmt.Sprintf("%s@%s", toolName, version))
 	if err != nil {
 		return "", fmt.Errorf("mise latest %s@%s: %w", toolName, version, err)
 	}
@@ -45,8 +43,7 @@ func (m *MiseToolProvider) resolveToLatestReleased(toolName string, version stri
 
 func (m *MiseToolProvider) resolveToLatestInstalled(toolName string, version string) (string, error) {
 	// Even if version is empty string "sometool@" will not cause an error.
-	cmd := exec.Command("mise", "latest", "--installed", fmt.Sprintf("%s@%s", toolName, version))
-	output, err := cmd.CombinedOutput()
+	output, err := m.ExecEnv.RunMise("latest", "--installed", fmt.Sprintf("%s@%s", toolName, version))
 	if err != nil {
 		return "", fmt.Errorf("mise latest --installed %s@%s: %w", toolName, version, err)
 	}


### PR DESCRIPTION
Implement Mise bootstrap by downloading a release and extracting the .tar.gz. This also means we can have a `ExecEnv` structure and use that for all Mise CLI executions throughout the package, just like with asdf.